### PR TITLE
Feature/improvements and remove django-advanced-filters

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,7 +1,8 @@
 web: ./manage.py collectstatic --no-input && uwsgi uwsgi.ini
 kill: kill -9 $(cat /tmp/dcoleman-master.pid) && rm /tmp/dcoleman-master.pid
-createdb: ./manage.py sqlcreate | DATABASE_URL=postgresql://postgres:$PG_PASSWORD@postgres:5432/postgres ./manage.py dbshell || true
+createdb: ./manage.py sqlcreate | DATABASE_URL=postgresql://postgres:$POSTGRES_PASSWORD@postgres:5432/postgres ./manage.py dbshell || true
 migrate: ./manage.py showmigrations && ./manage.py migrate
 makemigrations: ./manage.py makemigrations && ./manage.py makemigrations partner mtasks
 createadmin: ./manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_superuser('$ADMIN_USERNAME', password='$ADMIN_PASSWORD')" && printf "User $ADMIN_USERNAME/$ADMIN_PASSWORD created.\n---> DON'T forget to CHANGE the password <---\n"
+provision: honcho start createdb && honcho start migrate && honcho start createadmin
 test: pytest --cov --cov-report=html --cov-report=term-missing --no-cov-on-fail --color=yes

--- a/Procfile
+++ b/Procfile
@@ -1,6 +1,8 @@
 web: ./manage.py collectstatic --no-input && uwsgi uwsgi.ini
 kill: kill -9 $(cat /tmp/dcoleman-master.pid) && rm /tmp/dcoleman-master.pid
 createdb: ./manage.py sqlcreate | DATABASE_URL=postgresql://postgres:$POSTGRES_PASSWORD@postgres:5432/postgres ./manage.py dbshell || true
+collectstatic: ./manage.py collectstatic --no-input
+compilemessages: ./manage.py compilemessages --ignore 'venv*' --ignore '.venv*'
 migrate: ./manage.py showmigrations && ./manage.py migrate
 makemigrations: ./manage.py makemigrations && ./manage.py makemigrations partner mtasks
 createadmin: ./manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_superuser('$ADMIN_USERNAME', password='$ADMIN_PASSWORD')" && printf "User $ADMIN_USERNAME/$ADMIN_PASSWORD created.\n---> DON'T forget to CHANGE the password <---\n"

--- a/README.rst
+++ b/README.rst
@@ -18,8 +18,6 @@ Features
   to manage users and groups, login, etc.
 * Module `django-adminfilters <https://github.com/mrsarm/django-adminfilters>`_
   that allows multiselection searches.
-* Module `django-advanced-filters <https://github.com/modlinltd/django-advanced-filters>`_
-  that allows to make more complex searches.
 * Send emails when a task is created.
 * Spanish translations.
 * Basic Rest API configuration (disabled by default, check the
@@ -99,7 +97,7 @@ There are other shortcuts in the Procfile, like a command to
 create both the user and database (you have to provide the
 "master" password from the user "postgres" in an env variable)::
 
-    $  PG_PASSWORD=postgres honcho start createdb
+    $  POSTGRES_PASSWORD=postgres honcho start createdb
 
 And here is the command to automatically creates an "admin" user
 with password "admin1234"::

--- a/coleman/settings.py
+++ b/coleman/settings.py
@@ -141,6 +141,15 @@ USE_L10N = True
 USE_TZ = True
 
 
+from django.conf.locale.es import formats as es_formats
+es_formats.DATETIME_FORMAT = 'd M Y, H:i'
+es_formats.DATE_FORMAT = 'd M, Y'
+
+
+from django.conf.locale.en import formats as en_formats
+en_formats.DATETIME_FORMAT = 'M d Y, H:i'
+en_formats.DATE_FORMAT = 'M d, Y'
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 

--- a/coleman/settings.py
+++ b/coleman/settings.py
@@ -39,7 +39,6 @@ ALLOWED_HOSTS = [ '*' ]
 INSTALLED_APPS = [
     'mtasks.apps.MtasksConfig',
     'partner.apps.PartnerConfig',
-    'advanced_filters',
     'django_admin_listfilter_dropdown',
     'adminfilters',
     'django.contrib.admin',

--- a/coleman/settings_logging.py
+++ b/coleman/settings_logging.py
@@ -34,29 +34,29 @@ LOGGING = {
             'backupCount': 2,
             'formatter': 'verbose',
         },
-        # 'mail_admins': {
-        #     'level': 'ERROR',
-        #     'class': 'django.utils.log.AdminEmailHandler'
-        # }
+        'mail_admins': {
+            'level': 'ERROR',
+            'class': 'django.utils.log.AdminEmailHandler'
+        }
     },
     'loggers': {
         'django.request': {
-            'handlers': ['console', 'logfile'],
+            'handlers': ['console'],
             'level': LOG_LEVEL_DJANGO_REQ,
             'propagate': False,
         },
         'django.db.backends': {
-            'handlers': ['console', 'logfile'],
+            'handlers': ['console'],
             'propagate': False,
             'level': LOG_LEVEL_DJANGO_DB,
         },
         'django': {
-            'handlers': ['console', 'logfile'],
+            'handlers': ['console'],
             'propagate': True,
             'level': LOG_LEVEL_DJANGO,
         },
         '': {
-            'handlers': ['console', 'logfile'],
+            'handlers': ['console'],
             'level': LOG_LEVEL,
         },
     }

--- a/coleman/settings_test.py
+++ b/coleman/settings_test.py
@@ -3,10 +3,15 @@
 #
 
 # Import all general settings
+
 from .settings import *
+from . import env
 
 # Override below
 
-DATABASES = {
-    'default': { 'ENGINE': 'django.db.backends.sqlite3' }
-}
+if env('DATABASE_URL_TEST', None):
+    default = env.dj_db_url('DATABASE_URL_TEST')
+else:
+    default = {'ENGINE': 'django.db.backends.sqlite3'}
+
+DATABASES = {'default': default}

--- a/coleman/urls.py
+++ b/coleman/urls.py
@@ -28,7 +28,6 @@ router.register(r'tasks', TaskViewSet)
 
 
 urlpatterns = [
-    url(r'^advanced_filters/', include('advanced_filters.urls')),
     url(r'^api/v1/', include(router.urls)),
 ]
 

--- a/mtasks/admin.py
+++ b/mtasks/admin.py
@@ -1,5 +1,4 @@
 from adminfilters.multiselect import UnionFieldListFilter
-from advanced_filters.admin import AdminAdvancedFiltersMixin
 from django.contrib import admin
 from django.db import models
 from django.forms import Textarea
@@ -14,7 +13,7 @@ class ItemInline(admin.TabularInline):
 
 
 @admin.register(Task)
-class TaskAdmin(AdminAdvancedFiltersMixin, admin.ModelAdmin):
+class TaskAdmin(admin.ModelAdmin):
     list_display = ('number', 'title', 'user', 'partner', 'created_at', 'deadline', 'priority', 'state')
     list_display_links = ('number', 'title')
     search_fields = ('id', 'title', 'item__item_description',
@@ -26,18 +25,6 @@ class TaskAdmin(AdminAdvancedFiltersMixin, admin.ModelAdmin):
         ('state', UnionFieldListFilter),
         ('priority', UnionFieldListFilter),
         'deadline'
-    )
-    advanced_filter_fields = (
-        'user__username',
-        'partner__name',
-        'state',
-        'priority',
-        'deadline',
-        'created_at',
-        'created_by',
-        'title',
-        'description',
-        'resolution',
     )
     ordering = TASK_PRIORITY_FIELDS
     readonly_fields = ('created_at', 'last_modified', 'created_by')

--- a/mtasks/locale/es/LC_MESSAGES/django.po
+++ b/mtasks/locale/es/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-09 18:56-0300\n"
+"POT-Creation-Date: 2022-02-13 19:12-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Mariano Ruiz <mrsarm@gmail.com>\n"
 "Language: es\n"
@@ -24,110 +24,110 @@ msgstr "Mas información..."
 msgid " Task Management"
 msgstr " Gestión de Tareas"
 
-#: models.py:14
+#: models.py:15
 msgid "number"
 msgstr "número"
 
-#: models.py:33
+#: models.py:57
 msgid "Task"
 msgstr "Tarea"
 
-#: models.py:34
+#: models.py:58
 msgid "Tasks"
 msgstr "Tareas"
 
-#: models.py:38
+#: models.py:61
 msgid "To Do"
 msgstr "Para Hacer"
 
-#: models.py:39
+#: models.py:62
 msgid "In Progress"
 msgstr "En Progreso"
 
-#: models.py:40
+#: models.py:63
 msgid "Blocked"
 msgstr "Bloqueado"
 
-#: models.py:41
+#: models.py:64
 msgid "Done"
 msgstr "Hecho"
 
-#: models.py:42
+#: models.py:65
 msgid "Dismissed"
 msgstr "Desestimado"
 
-#: models.py:47
+#: models.py:69
 msgid "Low"
 msgstr "Baja"
 
-#: models.py:48
+#: models.py:70
 msgid "Normal"
 msgstr "Normal"
 
-#: models.py:49
+#: models.py:71
 msgid "High"
 msgstr "Alta"
 
-#: models.py:50
+#: models.py:72
 msgid "Critical"
 msgstr "Crítica"
 
-#: models.py:51
-msgid "Blocker"
-msgstr "Bloqueada"
-
-#: models.py:54
+#: models.py:75
 msgid "title"
 msgstr "título"
 
-#: models.py:56 models.py:161
+#: models.py:77 models.py:197
 msgid "description"
 msgstr "descripción"
 
-#: models.py:57
+#: models.py:78
 msgid "resolution"
 msgstr "resolución"
 
-#: models.py:58
+#: models.py:79
 msgid "deadline"
 msgstr "fecha límite"
 
-#: models.py:59
+#: models.py:80
 msgid "assigned to"
 msgstr "asignado a"
 
-#: models.py:61
+#: models.py:82
 msgid "state"
 msgstr "estado"
 
-#: models.py:62
+#: models.py:83
 msgid "priority"
 msgstr "prioridad"
 
-#: models.py:63
+#: models.py:84
 msgid "created by"
 msgstr "creado por"
 
-#: models.py:65
+#: models.py:86
 msgid "created at"
 msgstr "creado en"
 
-#: models.py:66
+#: models.py:87
 msgid "last modified"
 msgstr "última vez modificado"
 
-#: models.py:95
-msgid "Task with this title and partner already exists."
-msgstr "Tarea con mismo título y partner ya existe"
+#: models.py:123
+msgid "Open task with this title and partner already exists."
+msgstr "Una tarea abierta con mismo título y partner ya existe."
 
-#: models.py:157
+#: models.py:129
+msgid "Open task with this title and no partner already exists."
+msgstr "Una tarea abierta con mismo título y partner ya existe."
+
+#: models.py:193
 msgid "Item"
 msgstr "Item"
 
-#: models.py:158
+#: models.py:194
 msgid "Check List"
 msgstr "Check List"
 
-#: models.py:162
+#: models.py:198
 msgid "done?"
 msgstr "¿listo?"

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,4 @@ DJANGO_SETTINGS_MODULE = coleman.settings_test
 addopts = --create-db
 
 filterwarnings =
-    ignore:distutils Version classes are deprecated. Use packaging.version instead.:DeprecationWarning
+    ignore:The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives:DeprecationWarning

--- a/requirements.in
+++ b/requirements.in
@@ -5,17 +5,3 @@ django-admin-list-filter-dropdown~=1.0.3
 django-adminfilters~=1.9.0
 djangorestframework~=3.13.1
 django-extensions~=3.1.5
-
-### Workaround django-advanced-filters
-
-# The Latest version 1.4.0 doesn't work with Django 3.2, so forked version from
-# the pull request https://github.com/modlinltd/django-advanced-filters/pull/153 is used instead
-
-#django-advanced-filters==1.3.0
-
--e git://github.com/hzung/django-advanced-filters.git@ed934d24b0da2a78e3db16e0f000c2ea9cc4627c#egg=django-advanced-filters
-
-# Also six is needed although not declared as dependency
-six==1.16.0
-
-### END Workaround django-advanced-filters

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile --no-emit-index-url --output-file=requirements.txt requirements.in
 #
--e git+git://github.com/hzung/django-advanced-filters.git@ed934d24b0da2a78e3db16e0f000c2ea9cc4627c#egg=django-advanced-filters
-    # via -r requirements.in
 asgiref==3.4.1
     # via django
 dj-database-url==0.5.0
@@ -33,9 +31,5 @@ pytz==2021.3
     # via
     #   django
     #   djangorestframework
-simplejson==3.17.6
-    # via django-advanced-filters
-six==1.16.0
-    # via -r requirements.in
 sqlparse==0.4.2
     # via django


### PR DESCRIPTION
* Remove django-advanced-filters: Installing it from Github commit reference causes some issues in some environments, so removing it until a stable version works with modern Django versions again (it doesn't work with Django 3.2+: https://github.com/modlinltd/django-advanced-filters/pull/153).
* Add provision task that creates everything needed in the DB
* Use default env name from PG variable on createdb
* Set shorter dates and datetimes formats
* Log only in console by default
* Optionally set test database with `DATABASE_URL_TEST`
* Add more Honcho common tasks
* Fix translations